### PR TITLE
prevent ghost click on anchor elements

### DIFF
--- a/alloy_finger.js
+++ b/alloy_finger.js
@@ -176,6 +176,7 @@
             this.scale = 1;
             this.pinchStartLen = null;
             this.x1 = this.x2 = this.y1 = this.y2 = null;
+            evt.preventDefault();
         },
         cancel:function(evt){
             clearTimeout(this.touchTimeout);


### PR DESCRIPTION
假设有2个尺寸相同的元素，id为a的锚元素`<a>`在底层，id为b的任意元素`<div>`在顶层。
用例为：点击b元素后，b元素消失。
测试用例时，观察到b元素消失后，a元素会被点击穿透到，从而引发页面跳转。
现通过阻止默认事件避免此现象发生。