### PR TITLE
resolve base64 uri bug in safari

### DIFF
--- a/alloy_crop/alloy_crop.js
+++ b/alloy_crop/alloy_crop.js
@@ -21,7 +21,10 @@
         this.cover.height = window.innerHeight;
         this.cover_ctx = this.cover.getContext("2d");
         this.img = document.createElement("img");
-        this.img.crossOrigin = "Anonymous";
+        
+        if(option.image_src.substring(0,4).toLowerCase()==='http') {
+            this.img.crossOrigin = 'anonymous';//resolve base64 uri bug in safari:"cross-origin image load denied by cross-origin resource sharing policy."
+        }
         this.cancel = option.cancel;
         this.ok = option.ok;
 


### PR DESCRIPTION
in safari,if set base64 uri to img,browser will throw error:"cross-origin image load denied by cross-origin resource sharing policy."