### PR TITLE
Add evt.persist() to _handleTouchStart and _handleTouchMove to explic…

### DIFF
--- a/react/react-alloy_finger.jsx
+++ b/react/react-alloy_finger.jsx
@@ -64,8 +64,7 @@ export default class AlloyFinger extends React.Component {
     }
 
     _handleTouchStart (evt) {
-
-
+       evt.persist();
        this.now = Date.now();
        this.x1 = evt.touches[0].pageX;
        this.y1 = evt.touches[0].pageY;
@@ -91,6 +90,7 @@ export default class AlloyFinger extends React.Component {
     }
 
     _handleTouchMove(evt){
+        evt.persist();
         var preV = this.preV,
                     len = evt.touches.length,
                     currentX = evt.touches[0].pageX,


### PR DESCRIPTION
…itly take the event out of the pool and avoid the following warning:

Warning: This synthetic event is reused for performance reasons. If you're seeing this, you're adding a new property in the synthetic event object. The property is never released. See https://fb.me/react-event-pooling for more information.