### PR TITLE
Fix: parameter missing in function `_handleTouchCancel` of React version

### DIFF
--- a/react/AlloyFinger.jsx
+++ b/react/AlloyFinger.jsx
@@ -157,7 +157,7 @@ export default class AlloyFinger extends Component {
         }
     }
 
-    _handleTouchCancel() {
+    _handleTouchCancel(evt) {
         this._emitEvent('onTouchCancel', evt);
         clearInterval(this.singleTapTimeout);
         clearInterval(this.tapTimeout);


### PR DESCRIPTION
`_handleTouchCancel`函数的参数漏掉了没加，报错了。

发生在这次提交：
https://github.com/AlloyTeam/AlloyFinger/commit/f8376634390e5c3f0658b3092fb79218ed214ac0#diff-6a74522dfbc8d7ca015a6ca8fdeab411R160